### PR TITLE
match build_database function in smartos-live

### DIFF
--- a/create-smf-repo
+++ b/create-smf-repo
@@ -117,10 +117,9 @@ function build_database
 	rm -f $SVCCFG_REPOSITORY
 
 	[[ -f $input ]] || fail "can't read manifest input file: $input"
-	while read service enabled import; do
+	while read service enabled; do
 		[[ -z "$service" ]] && continue
 		[[ "$service" =~ ^\# ]] && continue
-		[[ "$import" == "noimport" ]] && continue
 		import_manifest $service $enabled
 		
 		echo $service $enabled


### PR DESCRIPTION
joyent/smartos-live#339 alters the build_database function
which was copied into create-smf-repo

This commit keeps the two versions in sync.

This should only be merged if/when joyent/smartos-live#339 gets merged or otherwise implemented.
